### PR TITLE
Clear editor history after setting the initial content

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -429,6 +429,7 @@ pimcore.bundle.quill.editor = Class.create({
             text: '\n'
         });
         this.activeEditor.updateContents(delta, Quill.sources.USER);
+        this.activeEditor.history.clear();
     }
 })
 


### PR DESCRIPTION
Currently the undo command (CTRL + Z) in the Quill Editor will also remove the original content that was set by Pimcore which can lead to unexpected changes.


## Changes in this pull request
Resetting the editor history after setting the editor content ensures that the original cannot be "undone"

