### PR TITLE
Remove studio conflict

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,6 @@
       "Pimcore\\Bundle\\QuillBundle\\": "src/"
     }
   },  
-  "conflict": {
-    "pimcore/studio-ui-bundle": "<0.5.20 || >0.5.20"
-  },
   "extra": {
     "pimcore": {
       "bundles": [


### PR DESCRIPTION
Otherwise the dev branches are not installable. We need to add a new conflict before the next release.