### PR TITLE
[Bug, EC] PEES-606: WYSIWYG Inheritance Issues In Admin 

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -126,10 +126,11 @@ pimcore.bundle.quill.editor = Class.create({
         this.activeEditor.on('text-change', () => {
             const tableModule = this.activeEditor.getModule('table-better');
             tableModule?.deleteTableTemporary();
+            const data = this.activeEditor.getSemanticHTML().replace(/<p>\s*<\/p>/g, '');
             document.dispatchEvent(new CustomEvent(pimcore.events.changeWysiwyg, {
                 detail: {
                     e: {target:{id: textareaId}},
-                    data: this.activeEditor.getSemanticHTML(),
+                    data: data,
                     context: e.detail.context
                 }
             }));


### PR DESCRIPTION
Remove the empty P tag, because otherwise inheritance doesn't work after deleting the content in the child wysiwyg
 
resolves https://github.com/pimcore/service-operations/issues/144