### PR TITLE
Deprecate Quill bundle from Platform LTS starting 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ title: Quill WYSIWYG Editor
 
 # Quill WYSIWYG Editor
 
+> **Deprecated:** This bundle is deprecated and will no longer be part of the
+> Pimcore Platform LTS starting with the 2027 release line. It remains fully
+> supported in the 2026.x LTS. Existing installations are not affected before
+> then, but new projects should evaluate alternative WYSIWYG editor bundles.
+
 Integrates the [Quill 2.x](https://quilljs.com/) WYSIWYG editor into Pimcore.
 Quill provides rich-text editing for documents, data objects, and shared translations.
 

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "pimcore/quill-bundle",
   "license": "proprietary",
   "type": "pimcore-bundle",
+  "abandoned": true,
   "config": {
     "discard-changes": true,
     "sort-packages": true,


### PR DESCRIPTION
## Summary
- Marks `pimcore/quill-bundle` as `abandoned` in composer.json
- Adds a deprecation notice to README.md stating the bundle will no longer be part of the Pimcore Platform LTS starting with the 2027 release line
- The bundle remains fully supported in the current 2026.x LTS; no functional changes

## Test plan
- [ ] Confirm `composer.json` remains valid (`composer validate`)
- [ ] Confirm README renders correctly on GitHub