### PR TITLE
Trigger studio frontend build on build-folder changes too

### DIFF
--- a/.github/workflows/studio-frontend-build.yaml
+++ b/.github/workflows/studio-frontend-build.yaml
@@ -4,9 +4,11 @@ on:
   push:
     paths:
       - "assets/studio/**"
+      - "public/studio/build/**"
   pull_request:
     paths:
       - "assets/studio/**"
+      - "public/studio/build/**"
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Adds the committed build-output folder (`public/studio/build/**`) to the push/PR path filters so a build that lands via an **upstream merge or manual edit** (touching the build folder but not `assets/studio` source) still re-triggers the build — catching the broken-merge / stale-bundle case.

Mirrors the pattern in `collab-bundle`; this repo's build folder is `public/studio/build/**`.

**Loop-safe:** the reusable workflow's commit jobs push with the default `GITHUB_TOKEN`, and GitHub does not re-trigger workflows on `GITHUB_TOKEN` pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)