### PR TITLE
Deprecate Quill bundle from Platform LTS starting 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@ title: Quill WYSIWYG Editor
 
 # Quill WYSIWYG Editor
 
+> **Deprecated:** This bundle is deprecated and will no longer be part of the Pimcore
+> Platform LTS starting with the 2027 release line. It remains fully supported in the
+> 2026.x LTS. See the [2026.3 release notes](https://github.com/pimcore/platform-version/blob/2026.x/doc/02_Pimcore_Platform/05_Updating_Pimcore/02_Release_Notes/01_2026.3.md)
+> for details.
+
 Integrates the [Quill 2.x](https://quilljs.com/) WYSIWYG editor into Pimcore.
 Quill provides rich-text editing for documents, data objects, and shared translations.
 

--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
   "name": "pimcore/quill-bundle",
   "license": "proprietary",
   "type": "pimcore-bundle",
+  "abandoned": true,
   "config": {
     "discard-changes": true,
     "sort-packages": true,


### PR DESCRIPTION
## Summary
- Marks `pimcore/quill-bundle` as `abandoned` in composer.json
- Adds a deprecation notice to the README

Quill remains fully supported in the 2026.x LTS line, but will no longer be part of the Pimcore Platform LTS starting with the 2027 release line.

See the corresponding platform-version PR documenting this in the 2026.3 release notes.