### PR TITLE
Drop DOCS_GENERATOR_ACCESS_TOKEN from docs workflow, downgrade to pull_request

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,14 +1,14 @@
 name: "Documentation (Reusable)"
 
 on:
-  pull_request_target:
+  pull_request:
     branches:
       - "[0-9]+.[0-9]+"
       - "[0-9]+.x"
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
   push:
     branches:
@@ -17,7 +17,7 @@ on:
       - "docs_actions"
     paths:
       - "doc/**"
-      - ".github/workflows/new-docs.yml"
+      - ".github/workflows/docs.yml"
       - "README.md"
 
 permissions:
@@ -28,5 +28,3 @@ jobs:
     uses: pimcore/workflows-collection-public/.github/workflows/reusable-docs.yaml@main
     with:
       docs_path: "doc"
-    secrets:
-      DOCS_GENERATOR_ACCESS_TOKEN: ${{ secrets.DOCS_GENERATOR_ACCESS_TOKEN }}


### PR DESCRIPTION
## Summary
Remove `DOCS_GENERATOR_ACCESS_TOKEN` from the docs workflow and downgrade its trigger from `pull_request_target` to plain `pull_request`.

The token was only needed to clone the private `docs-generator`; since pimcore/workflows-collection-public#135 (merged) vendors sanitized public tooling, no secret is needed: read-only token, no secret-exposure surface. Tracked in pimcore/product-management#1321 (org-wide cleanup, template: pimcore/pimcore#19292).

## Changes
- Drop the `secrets: DOCS_GENERATOR_ACCESS_TOKEN` block.
- `pull_request_target` → `pull_request`.
- Fix the stale `paths` entry `.github/workflows/new-docs.yml` → `docs.yml`, so changes to the docs workflow itself trigger a docs run.


## Verification
The pattern is live-proven in pimcore/pimcore#19292 — its docs run is green on the exact tokenless `@main` path. This PR's own docs run (triggered by the fixed `paths`) verifies this repo.

🤖 Generated with [Claude Code](https://claude.ai/code)
