### PR TITLE
Point PHP-CS-Fixer at reusable-php-cs-fixer.yaml@main

### DIFF
--- a/.github/workflows/php-cs-fixer.yaml
+++ b/.github/workflows/php-cs-fixer.yaml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   php-style:
-    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@fix-failed-workflow
+    uses: pimcore/workflows-collection-public/.github/workflows/reusable-php-cs-fixer.yaml@main
     with:
       head_ref: ${{ github.head_ref || github.ref_name }}
       repository: ${{ github.repository }}


### PR DESCRIPTION
The @fix-failed-workflow branch is stale (last commit 2025-11-25); @main is the org-wide convention and is backwards compatible for these inputs.

## Changes in this pull request
Resolves #

## Additional info
